### PR TITLE
Removed whitespace in variations

### DIFF
--- a/templates/single-product/add-to-cart/variation.php
+++ b/templates/single-product/add-to-cart/variation.php
@@ -15,17 +15,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <script type="text/template" id="tmpl-variation-template">
-	<div class="woocommerce-variation-description">
-		{{{ data.variation.variation_description }}}
-	</div>
+	<div class="woocommerce-variation-description">{{{ data.variation.variation_description }}}</div>
 
-	<div class="woocommerce-variation-price">
-		{{{ data.variation.price_html }}}
-	</div>
+	<div class="woocommerce-variation-price">{{{ data.variation.price_html }}}</div>
 
-	<div class="woocommerce-variation-availability">
-		{{{ data.variation.availability_html }}}
-	</div>
+	<div class="woocommerce-variation-availability">{{{ data.variation.availability_html }}}</div>
 </script>
 <script type="text/template" id="tmpl-unavailable-variation-template">
 	<p><?php _e( 'Sorry, this product is unavailable. Please choose a different combination.', 'woocommerce' ); ?></p>


### PR DESCRIPTION
Whitespace is added by formatting the lines with whitespace. This stops you from being able to target the element & check if it's empty with :empty etc.