### PR TITLE
Added filter for product title classes within product loop

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1082,7 +1082,7 @@ if ( ! function_exists( 'woocommerce_template_loop_product_title' ) ) {
 	 * Show the product title in the product loop. By default this is an H2.
 	 */
 	function woocommerce_template_loop_product_title() {
-		echo '<h2 class="woocommerce-loop-product__title">' . get_the_title() . '</h2>'; // phpcs:ignore
+		echo '<h2 class="' . apply_filters( 'woocommerce_product_loop_title_classes', 'woocommerce-loop-product__title' ) . '">' . get_the_title() . '</h2>'; // phpcs:ignore
 	}
 }
 if ( ! function_exists( 'woocommerce_template_loop_category_title' ) ) {

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1082,7 +1082,7 @@ if ( ! function_exists( 'woocommerce_template_loop_product_title' ) ) {
 	 * Show the product title in the product loop. By default this is an H2.
 	 */
 	function woocommerce_template_loop_product_title() {
-		echo '<h2 class="' . apply_filters( 'woocommerce_product_loop_title_classes', 'woocommerce-loop-product__title' ) . '">' . get_the_title() . '</h2>'; // phpcs:ignore
+		echo '<h2 class="' . esc_attr( apply_filters( 'woocommerce_product_loop_title_classes', 'woocommerce-loop-product__title' ) ) . '">' . get_the_title() . '</h2>'; // phpcs:ignore
 	}
 }
 if ( ! function_exists( 'woocommerce_template_loop_category_title' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds the ability to add classes to the hard-coded product title classes

### Other information:

* [ x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x ] Have you written new tests for your changes, as applicable?
* [x ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Filter for product title loop classes added